### PR TITLE
docs: :memo: fix cd command

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Dockerのインストールを完了させておくこと
 ```bash 
 cd
 cd Desktop
-cd myj-fastapi-web-app
+cd myj-fastapi-web-app-main
 ```
 
 2. 以下のコマンドを実行してprjを起動します。
@@ -81,7 +81,7 @@ docker-compose up コマンドを実行したウィンドウで `Ctrl + c`。
 ### プロジェクトの起動
 1. `cd`
 2. `cd Desktop`
-3. `cd myj-fastapi-web-app`
+3. `cd myj-fastapi-web-app-main`
 4. `docker-compose up`
 
 ### テーブル構造の変更をDBに反映


### PR DESCRIPTION
# 背景
<!-- なぜこの変更をやるのかをここに記載ください -->
> めっちゃ細かいんですけど、Download ZIPでダウンロードされるファイル名が今はmyj-fastapi-web-app-main-2になってませんか？
起動方法内の1のディレクトリ移動の部分修正必要かなと思ったのですが…
間違えてたらすみません

> あれ、それでもmyj-fastapi-web-app-mainであるはずではない？？

`Download ZIP`の場合はファイルは`<リポジ名>-<ブランチ名>.zip`になるので、`cd myj-fastapi-web-app`は正しくない

# 変更点
<!-- どんな変更をしたかをここに記載ください -->
Change all `cd myj-fastapi-web-app` to `cd myj-fastapi-web-app-main`

# check list
<!-- 
各項目確認してください
必要ない時は (xxのため必要ない) と記載ください
e.g. 
- [x] テストを書いた (doc変更のため必要ない)
- [x] テストを通した (doc変更のため必要ない)    
- [x] ドキュメントを更新した
-->
- [x] テストを書いた (doc変更のため必要ない)    
- [x] テストを通した (doc変更のため必要ない)    
- [x] ドキュメントを更新した