### PR TITLE
cookie認証を外す

### DIFF
--- a/api/extra_modules/auth/core.py
+++ b/api/extra_modules/auth/core.py
@@ -2,12 +2,12 @@ import typing as T
 from datetime import datetime, timedelta, timezone
 
 from fastapi import Depends, HTTPException, status
-from fastapi.security import APIKeyCookie, OAuth2PasswordBearer
+from fastapi.security import OAuth2PasswordBearer
 from jose import JWTError, jwt
 from sqlalchemy.orm import Session
 
-import api.extra_modules.auth.schema as auth_schemas
 import api.cruds.user as user_crud
+import api.extra_modules.auth.schema as auth_schemas
 from api.db import get_db
 
 # ! 本当は環境変数などから取得するべき
@@ -15,7 +15,6 @@ SECRET_KEY = "6ae97a28c3884986c02e1160313d30c2a065bbc4b14e4f6400085dd3e8afa6ea"
 ALGORITHM = "HS256"
 
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token", auto_error=False)
-cookie_scheme = APIKeyCookie(name="Authorization", auto_error=False)
 
 
 def create_access_token(
@@ -38,14 +37,12 @@ def create_access_token(
 
 def get_current_user(
     db: Session = Depends(get_db),
-    header_token: str | None = Depends(oauth2_scheme),
-    cookie_token: str | None = Depends(cookie_scheme),
+    token: str | None = Depends(oauth2_scheme),
 ):
     """
     tokenを検証し、userを返します。
 
-    tokenはheaderまたはcookieのどちらからも取得できます。
-    両方ある場合はheaderを優先します。両方ない場合はエラーを返します。
+    tokenはheaderのAuthorizationかcookieのtokenから取得します。
     """
 
     credentials_exception = HTTPException(
@@ -54,7 +51,6 @@ def get_current_user(
         headers={"WWW-Authenticate": "Bearer"},
     )
 
-    token = header_token or cookie_token
     if token is None:
         raise credentials_exception
 

--- a/api/extra_modules/auth/core.py
+++ b/api/extra_modules/auth/core.py
@@ -42,7 +42,7 @@ def get_current_user(
     """
     tokenを検証し、userを返します。
 
-    tokenはheaderのAuthorizationかcookieのtokenから取得します。
+    tokenはheaderのAuthorizationから取得します。
     """
 
     credentials_exception = HTTPException(

--- a/api/extra_modules/auth/routers.py
+++ b/api/extra_modules/auth/routers.py
@@ -1,6 +1,6 @@
 from datetime import timedelta
 
-from fastapi import APIRouter, Depends, HTTPException, Response, status
+from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.security import OAuth2PasswordRequestForm
 from sqlalchemy.orm import Session
 
@@ -15,7 +15,6 @@ router = APIRouter()
 
 @router.post("/token")
 def login_for_access_token(
-    response: Response,
     db: Session = Depends(get_db),
     form_data: OAuth2PasswordRequestForm = Depends(),
 ) -> auth_schemas.Token:
@@ -40,13 +39,6 @@ def login_for_access_token(
     access_token = create_access_token(
         data={"sub": user.get("email")},
         expires_delta=access_token_expires,
-    )
-
-    response.set_cookie(
-        key="Authorization",
-        value=access_token,
-        httponly=True,
-        max_age=ACCESS_TOKEN_EXPIRE_MINUTES,
     )
 
     return auth_schemas.Token(access_token=access_token, token_type="bearer")

--- a/api/routers/done.py
+++ b/api/routers/done.py
@@ -16,7 +16,7 @@ def mark_task_as_done(
     current_user: dict = Depends(get_current_user),
 ):
     task = task_crud.get_task(db, task_id=task_id)
-    # 存在したい場合
+    # 存在しない場合
     if task is None:
         raise HTTPException(status_code=404, detail="Task not found")
     # 違うユーザーのタスクを変更しようとした場合

--- a/script/sata/insert_mock.py
+++ b/script/sata/insert_mock.py
@@ -51,7 +51,9 @@ def insert_mock_task():
     for user, num_of_tasks in zip(user_data, num_of_tasks_for_each_user):
         if num_of_tasks == 0:
             continue
-        login_res = login(user["email"], user["password"])
+        login_json = login(user["email"], user["password"]).json()
+        token = f"{login_json['token_type']} {login_json['access_token']}"
+        token_header = {"Authorization": token}
 
         url = host + "/task"
         res_list = []
@@ -64,7 +66,7 @@ def insert_mock_task():
             res = requests.post(
                 url,
                 json=payload,
-                cookies=login_res.cookies,
+                headers=token_header,
             )
             if not res.ok:
                 print(res.json())
@@ -78,7 +80,7 @@ def insert_mock_task():
             image_res = requests.put(
                 f"{url}/{res.json()['id']}/image",
                 files={"image": ("image.png", fake.image(), "image/png")},
-                cookies=login_res.cookies,
+                headers=token_header,
             )
             if not image_res.ok:
                 print(res.json())
@@ -90,7 +92,7 @@ def insert_mock_task():
         ):
             done_res = requests.put(
                 f"{url}/{res.json()['id']}/done",
-                cookies=login_res.cookies,
+                headers=token_header,
             )
             if not done_res.ok:
                 print(res.json())


### PR DESCRIPTION
# 背景
<!-- なぜこの変更をやるのかをここに記載ください -->

現在、認証トークンはクッキーとHTTPヘッダーの両方で処理可能な状態となっている。これは当初、学生の負担を軽減するためにクッキー管理を導入したためである。しかし、現在はトークンのヘッダー管理も十分扱える前提となっており、両方式を併用する必要がなくなった。
また、Swagger UIはクッキーに対応しておらず、ログアウト後もクッキーが残るため、期待通りの挙動にならないケースがある。これを解消し、認証方式を明確化するため、クッキー認証を廃止し、ヘッダー方式に一本化する。

# 変更点
<!-- どんな変更をしたかをここに記載ください -->
- cookie認証を外した
- テストを修正した
- スクリプトを修正した

# check list
<!-- 
各項目確認してください
必要ない時は (xxのため必要ない) と記載ください
e.g. 
- [x] テストを書いた (doc変更のため必要ない)
- [x] テストを通した (doc変更のため必要ない)    
- [x] ドキュメントを更新した
-->
- [x] テストを書いた
- [x] テストを通した
- [x] ドキュメントを更新した