### PR TITLE
fix: propagate errors in all places when use `.catch`

### DIFF
--- a/frontend/login.html
+++ b/frontend/login.html
@@ -61,6 +61,7 @@
       })
       .catch((error) => {
         megsBox.innerText = error.message
+        throw error
       })
   }
 </script>

--- a/frontend/signup.html
+++ b/frontend/signup.html
@@ -71,6 +71,7 @@
       })
       .catch((error) => {
         megsBox.innerText = error.message
+        throw error
       })
   }
 </script>

--- a/frontend/task-detail.html
+++ b/frontend/task-detail.html
@@ -57,6 +57,7 @@
     })
     .catch(error => {
       location.href = '/index.html'
+      throw error
     })
 
   const deleteTask = () => {
@@ -71,6 +72,7 @@
       })
       .catch(error => {
         alert('削除に失敗しました')
+        throw error
       })
   }
 </script>


### PR DESCRIPTION
# 背景
<!-- なぜこの変更をやるのかをここに記載ください -->
- https://github.com/orgs/myjlab/projects/3/views/3?pane=issue&itemId=68963006

# 変更点
<!-- どんな変更をしたかをここに記載ください -->
- `.catch`されたエラーを伝播するようにした